### PR TITLE
Remove common prints

### DIFF
--- a/viz_3dtiles/Cesium3DTile.py
+++ b/viz_3dtiles/Cesium3DTile.py
@@ -35,6 +35,46 @@ class Cesium3DTile:
         # e.g { centroid_within_tile: True }
         self.filter_by_attributes = {}
 
+    def set_save_to_path(self, path):
+        """
+        The filepath to save the 3DTile. If the path does not exist, it will be created (handled by package py3dtiles)
+
+        Parameters
+        ----------
+        path : string
+            The destination of the 3DTile.
+        """
+        self.save_to = path
+
+    def set_b3dm_name(self, name):
+        """
+        Set the filename, not filepath or extension, of the 3DTile.
+
+        Parameters
+        ----------
+        name : string
+            The filename (not path) of the 3DTile.
+        """
+        self.save_as = name
+
+    def get_all_properties(self):
+        """
+        Get all proerties of the Cesium3DTile class as a dictionary.
+        """
+        return {
+            "z": self.z,
+            "geodataframe": self.geodataframe,
+            "save_as": self.save_as,
+            "save_to": self.save_to,
+            "max_features": self.max_features,
+            "geometries": self.geometries,
+            "gltf": self.gltf,
+            "debugCreateGLB": self.debugCreateGLB,
+            "max_width": self.max_width,
+            "min_tileset_z": self.min_tileset_z,
+            "max_tileset_z": self.max_tileset_z,
+            "filter_by_attributes": self.filter_by_attributes,
+        }
 
     def from_file(self, filepath, crs="EPSG:3413"):
         """

--- a/viz_3dtiles/Cesium3DTile.py
+++ b/viz_3dtiles/Cesium3DTile.py
@@ -3,7 +3,7 @@ import geopandas
 from geopandas.geodataframe import GeoDataFrame
 from shapely.geometry import Polygon, MultiPolygon
 from shapely import ops
-from py3dtiles import GlTF, TriangleSoup, B3dm
+from py3dtiles import GlTF, TriangleSoup, B3dm, BatchTable
 import numpy as np
 import json
 import os
@@ -150,14 +150,14 @@ class Cesium3DTile:
         row = 0
         for feature in self.geodataframe.iterfeatures():
 
-            print(f"Processing {row + 1} of {len(self.geodataframe)} in EPSG", self.CESIUM_EPSG)
+            # print(f"Processing {row + 1} of {len(self.geodataframe)} in EPSG", self.CESIUM_EPSG)
 
             # Create a multipolygon for only this polygon feature
             polygon=Polygon(feature["geometry"]["coordinates"][0])
             multipolygon = MultiPolygon([polygon])
 
             # use the TriangleSoup helper class to transform the wkb into arrays of points and normals
-            print(f"Tesselating polygon to generate position and normal arrays")
+            # print(f"Tesselating polygon to generate position and normal arrays")
             ts = TriangleSoup.from_wkb_multipolygon(multipolygon.wkb)
             positions = ts.getPositionArray()
             normals = ts.getNormalArray()


### PR DESCRIPTION
Some prints are so frequent they slow down execution and clutter the logs. Here I propose removing these two:

```
Tesselating polygon to generate position and normal arrays
Processing 559 of 5971 in EPSG 4978
```
Thanks!