### PR TITLE
Add install_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,10 @@ setup(name='viz_3dtiles',
       license='Apache License Version 2.0',
       packages=['viz_3dtiles'],
       python_requires='>=3.5',
+      install_requires=[
+        'numpy >= 1.20, < 2.0',
+        'pandas >= 1.4, < 2.0',
+        'geopandas >= 0.10, < 1.0',
+        'pdgpy3dtiles @ git+https://github.com/PermafrostDiscoveryGateway/py3dtiles.git#egg=pdgpy3dtiles'
+      ],
       zip_safe=False)


### PR DESCRIPTION
With these changes, I was able to run `pip install path/to/viz-3dtiles` in a fresh conda environment