### PR TITLE
removed prints, wrapped self.tiles = [tiles] in python list

### DIFF
--- a/viz_3dtiles/Cesium3DTile.py
+++ b/viz_3dtiles/Cesium3DTile.py
@@ -205,7 +205,7 @@ class Cesium3DTile:
 
         transform = transform.flatten('F')
 
-        print("creating glTF")
+        # print("creating glTF")
         gltf = GlTF.from_binary_arrays(self.geometries, transform=transform, batched=True)
 
         if self.debugCreateGLB == True:
@@ -215,7 +215,7 @@ class Cesium3DTile:
         self.gltf = gltf
 
     def create_batch_table(self):
-        print("Creating Batch table")
+        # print("Creating Batch table")
 
         bt = BatchTable()
 
@@ -229,7 +229,7 @@ class Cesium3DTile:
         attributes = self.geodataframe.columns.drop("geometry")
 
         for attr in attributes:
-            print("Adding " + attr)
+            # print("Adding " + attr)
             values=[]
             for v in self.geodataframe[attr].values:
                 values.append(str(v))
@@ -246,7 +246,7 @@ class Cesium3DTile:
 
         # --- Convert to b3dm -----
         # create a b3dm tile_content directly from the glTF.
-        print("Creating b3dm file")
+        # print("Creating b3dm file")
         t = B3dm.from_glTF(self.gltf, bt=self.create_batch_table())
 
         # to save our tile as a .b3dm file

--- a/viz_3dtiles/Cesium3DTileset.py
+++ b/viz_3dtiles/Cesium3DTileset.py
@@ -9,7 +9,7 @@ class Cesium3DTileset:
     FILE_EXT="json"
 
     def __init__(self, tiles=[]):
-        self.tiles = tiles
+        self.tiles = [tiles]
         self.save_as="tileset"
         self.save_to="~/"
         self.bbox = []
@@ -36,7 +36,7 @@ class Cesium3DTileset:
         self.tiles.append(tile)
     
     def get_boundingbox(self):
-        print(f"boundingVolume box for Cesium tileset")
+        # print(f"boundingVolume box for Cesium tileset")
 
         # TODO: Support tilesets with more than one tile. Iterate over tiles and find bounding box of all.
         tile = self.tiles[0]


### PR DESCRIPTION
I commented out current print statements so I can see what's happening while using the package (especially over many files). 

One change to be aware of, I changed the init which was `self.tiles = tiles` to `self.tile = [tiles]` which allows the code to run as is without further changes. 

Thanks, hope this sounds good to you!